### PR TITLE
several fixes ( see description for more details)

### DIFF
--- a/Valley.Net.Protocols.MeterBus/EN13757_2/VIF.cs
+++ b/Valley.Net.Protocols.MeterBus/EN13757_2/VIF.cs
@@ -91,7 +91,7 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
             Magnitude = record.Magnitude(data);
             Name = record.Name(record.Magnitude(data));
             Quantity = record.Quantity;
-            VIF_string = record.VIF.ToString("X");
+            VIF_string = record.VIF.ToString("X2")+"h";
         }
 
 

--- a/Valley.Net.Protocols.MeterBus/EN13757_2/VIF.cs
+++ b/Valley.Net.Protocols.MeterBus/EN13757_2/VIF.cs
@@ -40,7 +40,7 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
 
         public string Quantity { get; set; }
 
-        public string VIF_string { get; set; }
+        public string VIF_string { get;  }
 
         public string Name { get; set; }
 
@@ -91,7 +91,9 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
             Magnitude = record.Magnitude(data);
             Name = record.Name(record.Magnitude(data));
             Quantity = record.Quantity;
+            VIF_string = record.VIF.ToString("X");
         }
+
 
         public static readonly VifTableRecord[] VifFixedTable =
         {
@@ -325,10 +327,10 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
             new VifTableRecord ( 0x73, 86400.0, "s", "Averaging Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Averaging Duration (days)"),  /* days    */
 
             /* E111 01nn     Actuality Duration s */
-            new VifTableRecord ( 0x74,     1.0, "s", "Averaging Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Averaging Duration (seconds)"),  /* seconds */
-            new VifTableRecord ( 0x75,    60.0, "s", "Averaging Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Averaging Duration (minutes)"),  /* minutes */
-            new VifTableRecord ( 0x76,  3600.0, "s", "Averaging Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Averaging Duration (hours)"),  /* hours   */
-            new VifTableRecord ( 0x77, 86400.0, "s", "Averaging Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Averaging Duration (days)"),  /* days    */
+            new VifTableRecord ( 0x74,     1.0, "s", "Actuality Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Actuality Duration (seconds)"),  /* seconds */
+            new VifTableRecord ( 0x75,    60.0, "s", "Actuality Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Actuality Duration (minutes)"),  /* minutes */
+            new VifTableRecord ( 0x76,  3600.0, "s", "Actuality Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Actuality Duration (hours)"),  /* hours   */
+            new VifTableRecord ( 0x77, 86400.0, "s", "Actuality Duration", VariableDataQuantityUnit.AveragingDuration, VIF.VifType.PrimaryVIF, b => (b & 0x03), n => "Actuality Duration (days)"),  /* days    */
 
             /* Fabrication No */
             new VifTableRecord ( 0x78, 1.0, "", "Fabrication No", VariableDataQuantityUnit.FabricationNo, VIF.VifType.PrimaryVIF, b => 0, n => "Fabrication No"),

--- a/Valley.Net.Protocols.MeterBus/EN13757_3/VariableDataPacket.cs
+++ b/Valley.Net.Protocols.MeterBus/EN13757_3/VariableDataPacket.cs
@@ -71,7 +71,7 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_3
                             (u.Units != VariableDataQuantityUnit.MultiplicativeCorrectionFactor1000) &&
                             (u.Units != VariableDataQuantityUnit.AdditiveCorrectionConstant) &&
                             true)
-                        .Select(u => u.VIF_string ?? u.Units.ToString())), Function, Tariff, SubUnit);
+                        .Select(u => u.VIF_string == null ? string.Empty : $"{u.VIF_string}." + u.Units.ToString())), Function, Tariff, SubUnit);
 
             public Tuple<string, object> NormalizedValue
             {

--- a/Valley.Net.Protocols.MeterBus/Valley.Net.Protocols.MeterBus.csproj
+++ b/Valley.Net.Protocols.MeterBus/Valley.Net.Protocols.MeterBus.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Martin Dahlstedt</Authors>
     <Company>Valley</Company>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixed: The Actuality Duration was named Averaging Duration before
fixed: The VIF_string is set now, before it was always null
fixed: VariableDataPackage.Recor.Name includes now VIF (if exists) and Unit name.
info: upgraded package version to 1.0.3