### PR TITLE
FIX VIF ASCII

### DIFF
--- a/Valley.Net.Protocols.MeterBus.Test/PacketSerializationTests.cs
+++ b/Valley.Net.Protocols.MeterBus.Test/PacketSerializationTests.cs
@@ -1248,5 +1248,41 @@ namespace Valley.Net.Protocols.MeterBus.Test
 
             Assert.IsNotNull(packet);
         }
+
+        [TestMethod]
+        public void Test_VIF_ASCII_Meter()
+        {
+            var data = "68 56 56 68 08 5F 72 91 91 01 19 77 04 14 16 A0 00 00 00 0C 78 91 91 01 19 0D 7C 08 44 49 20 2E 74 73 75 63 0A 20 20 20 20 20 20 20 20 20 20 04 6D 00 0C 8A 26 02 7C 09 65 6D 69 74 20 2E 74 61 62 4A 14 04 14 0D 7A 05 00 04 94 7F 00 00 00 00 44 14 57 B0 04 00 0F 00 01 1F 22 16"
+                .HexToBytes();
+            var frame = new MeterbusFrameSerializer()
+                .Deserialize<VariableDataLongFrame>(data, 0, data.Length);
+
+            Assert.IsNotNull(frame);
+
+            var packet = frame.ToPacket() as VariableDataPacket;
+
+            foreach (var r in packet.Records)
+            {
+                var Dimension = r.Units[0].Unit;
+                var Description = r.Units[0].Units;
+                double Value;
+                try
+                {
+                    if (r.Units[0].Units == Valley.Net.Protocols.MeterBus.EN13757_2.VariableDataQuantityUnit.TimePoint)
+                        Value = System.Convert.ToDouble(r.Value);
+                    else
+                        Value = System.Convert.ToDouble(r.NormalizedValue.Item2);
+                }
+                catch (Exception ex)
+                {
+                    //Value = System.Convert.ToDouble(r.NormalizedValue.Item2);
+                }
+                var Type = r.Function;
+                var StoreageNumber = (long)r.StorageNumber;
+                var Tariff = (int)r.Tariff;
+            }
+
+            Assert.IsNotNull(packet);
+        }
     }
 }

--- a/Valley.Net.Protocols.MeterBus/EN13757_2/Value.cs
+++ b/Valley.Net.Protocols.MeterBus/EN13757_2/Value.cs
@@ -7,7 +7,7 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
     public sealed class Value : Part
     {
         public byte[] Data { get; private set; }
-
+        public object LVARvalue { get; set; }
         public Value(byte[] data)
         {
             Data = data;

--- a/Valley.Net.Protocols.MeterBus/EN13757_2/VariableDataLongFrame.cs
+++ b/Valley.Net.Protocols.MeterBus/EN13757_2/VariableDataLongFrame.cs
@@ -114,9 +114,21 @@ namespace Valley.Net.Protocols.MeterBus.EN13757_2
                                     }
                                 }
 
-                                var valueLength = dif.DataType == DataTypes._variable_length ? -1 : LenghtsInBitsTable[dif.DataType] / 8;
 
-                                var value = new Value(valueLength > 0 ? reader.ReadBytes(valueLength) : null);
+                                if (vif.Type == VIF.VifType.PlainTextVIF)
+                                    vif.Unit = BinaryReaderExtensions.ReadValue(reader).ToString();
+
+                                EN13757_2.Value value;
+                                if (dif.DataType == DataTypes._variable_length)
+                                {
+                                    value = new Value(new byte[0]);
+                                    value.LVARvalue = BinaryReaderExtensions.ReadValue(reader);
+                                }
+                                else
+                                {
+                                    var valueLength = dif.DataType == DataTypes._variable_length ? -1 : LenghtsInBitsTable[dif.DataType] / 8;
+                                    value = new Value(valueLength > 0 ? reader.ReadBytes(valueLength) : null);
+                                }
 
                                 Parts.Add(value);
                             }


### PR DESCRIPTION
Fix the support of VIF Codes ins ASCII Format:

if a device is responding a user defined VIF 0x7c (Plain Text) is not supported and causes all next records to be broken or causen an exception!
See https://m-bus.com/assets/downloads/MBDOC48.PDF page 42.

It can be reproduced with following device response:
"68 56 56 68 08 5F 72 91 91 01 19 77 04 14 16 A0 00 00 00 0C 78 91 91 01 19 0D 7C 08 44 49 20 2E 74 73 75 63 0A 20 20 20 20 20 20 20 20 20 20 04 6D 00 0C 8A 26 02 7C 09 65 6D 69 74 20 2E 74 61 62 4A 14 04 14 0D 7A 05 00 04 94 7F 00 00 00 00 44 14 57 B0 04 00 0F 00 01 1F 22 16"

see also issue: https://github.com/sympthom/Valley.Net.Protocols.MeterBus/issues/12